### PR TITLE
[Fix] MapStruct 및 Lombok-MapStruct-Binding 의존성 설정 오류 수정 (#40)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.6'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.team2'
@@ -9,36 +9,36 @@ version = '0.0.1-SNAPSHOT'
 description = 'HR Bank Project'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     //mapstruct
     implementation 'org.mapstruct:mapstruct:1.6.3'
-    implementation 'org.mapstruct:mapstruct-processor:1.6.3'
-    implementation 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
@@ -52,5 +52,5 @@ dependencies {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }


### PR DESCRIPTION
 Resolves #40 
 
 **[Fix] MapStruct 및 Lombok-MapStruct-Binding 의존성 설정 오류 수정**
 
 이 PR은 `build.gradle` 파일에서 `org.mapstruct:mapstruct-processor`와 `org.projectlombok:lombok-mapstruct-binding` 의존성이 `implementation`으로 잘못 설정되어 있던 문제를 수정합니다.
 
 **문제점:**
 Annotation Processor는 컴파일 시점에 코드를 생성하는 역할을 하므로 `implementation`이 아닌 `annotationProcessor` 설정으로 선언되어야 합니다. 잘못된 설정으로 인해 MapStruct 프로세서가 정상적으로 동작하지 않거나 빌드 시 문제가 발생할 수 있었습니다.
 
 **해결 방안:**
 해당 의존성들을 `implementation`에서 `annotationProcessor`로 변경하여 올바른 Gradle 설정으로 수정했습니다.
 
 **변경 내용:**
```groovy
// 변경 전 (As-Is)
// implementation 'org.mapstruct:mapstruct-processor:1.6.3'
// implementation 'org.projectlombok:lombok-mapstruct-binding:0.2.0'

// 변경 후 (To-Be)
annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
``` 
 
 **참고:** MapStruct 공식 문서의 Gradle 설정 가이드
https://mapstruct.org/documentation/stable/reference/html/#:~:text=Example%20133.%20Gradle%20configuration%20(3.4%20and%20later
 
 **검증 방법:**
 `./gradlew clean build` 명령어를 통해 프로젝트가 정상적으로 빌드되는 것을 확인했습니다.
