### PR TITLE
[Fix]: QueryDSL-APT가 JPA를 기반으로 클래스를 생성하도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     //querydsl
     implementation 'io.github.openfeign.querydsl:querydsl-jpa:7.0'
-    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:7.0'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:7.0:jpa'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
Resolves #44 

querydsl-apt이 엔티티를 기반으로 QClass를 생성하지 않는 문제를 해결하기 위해 build.gradle의 설정을 변경하였습니다.

**변경 사항**

```
// 변경 전
// annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:7.0'

// 변경 후
annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:7.0:jpa'
```

./gradlew clean build 명령어를 사용하여 build 패키지의 generated에서 QClass가 정상적으로 생성되는 것을 확인하였습니다.