### PR TITLE
[Feat] EmployeeService: 백업용 직원 정보 페이지네이션 API 및 DTO 정의 (#47)

### DIFF
--- a/src/main/java/com/team2/hrbank/employee/EmployeeService.java
+++ b/src/main/java/com/team2/hrbank/employee/EmployeeService.java
@@ -24,4 +24,6 @@ public interface EmployeeService {
     List<EmployeeDistributionDto> getEmployeeDistributions(String groupBy, EmployeeStatus status);
 
     Long getEmployeeCount(EmployeeStatus status, LocalDate fromDate, LocalDate toDate);
+
+    BackupEmployeePageResponseDto getEmployees(BackupEmployeePageRequestDto employee);
 }

--- a/src/main/java/com/team2/hrbank/employee/dto/BackupEmployeeDto.java
+++ b/src/main/java/com/team2/hrbank/employee/dto/BackupEmployeeDto.java
@@ -1,0 +1,15 @@
+package com.team2.hrbank.employee.dto;
+
+import java.time.LocalDate;
+
+public record BackupEmployeeDto(
+        Long id,
+        String employeeNumber,
+        String name,
+        String email,
+        String departmentName,
+        String position,
+        LocalDate hireDate,
+        String status
+) {
+}

--- a/src/main/java/com/team2/hrbank/employee/dto/BackupEmployeePageRequestDto.java
+++ b/src/main/java/com/team2/hrbank/employee/dto/BackupEmployeePageRequestDto.java
@@ -1,0 +1,8 @@
+package com.team2.hrbank.employee.dto;
+
+public record BackupEmployeePageRequestDto(
+        Long cursor,
+        Long idAfter,
+        Integer size
+) {
+}

--- a/src/main/java/com/team2/hrbank/employee/dto/BackupEmployeePageResponseDto.java
+++ b/src/main/java/com/team2/hrbank/employee/dto/BackupEmployeePageResponseDto.java
@@ -1,0 +1,13 @@
+package com.team2.hrbank.employee.dto;
+
+import java.util.List;
+
+public record BackupEmployeePageResponseDto(
+        List<BackupEmployeeDto> content,
+        String nextCursor,
+        Long nextIdAfter,
+        Integer size,
+        Long totalElements,
+        Boolean hasNext
+) {
+}


### PR DESCRIPTION
Resolves #47

**[Feat] EmployeeService: 백업용 직원 정보 페이지네이션 API 및 DTO 정의**

이 PR은 Issue에서 정의된 `EmployeeService`의 백업용 직원 정보 페이지네이션 API 및 관련 DTO 정의 작업을 완료합니다.

**주요 변경 사항:**

1.  **`EmployeeService` 페이지네이션 API 정의:**
    *   백업 기능을 위한 직원 정보 페이지 조회 메소드를 `EmployeeService`에 정의했습니다.
2.  **DTO 정의 및 변경:**
    *   **`EmployeeBackupDto` -> `BackupEmployeeDto`로 이름 변경:** DTO의 명확성을 위해 이름을 변경했습니다.
    *   **`BackupEmployeeDto`의 `status` 필드 타입 변경:**
        *   기존 `EmployeeStatus` Enum 타입에서 `String` 타입으로 변경했습니다.
        *   **변경 사유:** `Employee` 모듈과 `Backup` 모듈 간의 불필요한 Enum 의존성 공유를 방지하고, 모듈 간 결합도를 낮추기 위함입니다.

**코드 리뷰 요청 사항:**

*   `EmployeeService`에 정의된 페이지네이션 API의 적절성
*   `BackupEmployeeDto` 및 관련 페이지네이션 DTO들의 설계 적합성
*   `status` 필드를 `String`으로 변경한 결정이 모듈 간 의존성 관리에 미치는 영향 및 적절성
